### PR TITLE
Prep for v0.2

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -3,11 +3,11 @@ run:
 linters:
   enable:
     - bodyclose
+    - copyloopvar
     - depguard
     - dogsled
     - dupl
     - durationcheck
-    - exportloopref
     - exhaustive
     - gochecknoinits
     - goconst

--- a/go.mod
+++ b/go.mod
@@ -1,5 +1,5 @@
 module github.com/aauren/rtorrent
 
-go 1.22
+go 1.23
 
 require github.com/kolo/xmlrpc v0.0.0-20220921171641-a4b6fa1dd06b

--- a/rtorrent/downloads.go
+++ b/rtorrent/downloads.go
@@ -61,7 +61,7 @@ func (s *DownloadService) Active() ([]string, error) {
 
 // DownloadWithDetails retrieves a list of downloads from rTorrent along with additional details as specified by the commands slice.
 func (s *DownloadService) DownloadWithDetails(commands []string) ([][]any, error) {
-	newCmds := append([]string{"active"}, commands...)
+	newCmds := append([]string{"default"}, commands...)
 	return s.c.getSliceSlice(downloadListMultiCall, newCmds...)
 }
 

--- a/rtorrent/rtorrent.go
+++ b/rtorrent/rtorrent.go
@@ -84,9 +84,7 @@ func (c *Client) getString(method string, arg string) (string, error) {
 //nolint:unparam // we don't care about download_list being the only method so far
 func (c *Client) getStringSlice(method string, args ...string) ([]string, error) {
 	send := []interface{}{""}
-	for _, a := range args {
-		send = append(send, a)
-	}
+	send = append(send, args)
 
 	var v []string
 	err := c.xrc.Call(method, send, &v)
@@ -96,9 +94,7 @@ func (c *Client) getStringSlice(method string, args ...string) ([]string, error)
 // getSliceSlice retrieves a slice of slice values from the specified XML-RPC method.
 func (c *Client) getSliceSlice(method string, args ...string) ([][]any, error) {
 	send := []interface{}{""}
-	for _, a := range args {
-		send = append(send, a)
-	}
+	send = append(send, args)
 
 	var v [][]any
 	err := c.xrc.Call(method, send, &v)


### PR DESCRIPTION
Fixes issue where getting the active torrent only counts currently active torrents.

Also updates to Go 1.23 and removes a needless loop iteration on an array concatenate.