### PR TITLE
Prep v0.2.1

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v5
         with:
-          go-version: '1.22.x'
+          go-version: '1.23.x'
       - name: Install dependencies
         run: go mod download
       - name: Build

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -23,4 +23,4 @@ jobs:
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v6
         with:
-          version: v1.59
+          version: v1.62

--- a/rtorrent/rtorrent.go
+++ b/rtorrent/rtorrent.go
@@ -84,7 +84,9 @@ func (c *Client) getString(method string, arg string) (string, error) {
 //nolint:unparam // we don't care about download_list being the only method so far
 func (c *Client) getStringSlice(method string, args ...string) ([]string, error) {
 	send := []interface{}{""}
-	send = append(send, args)
+	for _, a := range args {
+		send = append(send, a)
+	}
 
 	var v []string
 	err := c.xrc.Call(method, send, &v)
@@ -94,7 +96,9 @@ func (c *Client) getStringSlice(method string, args ...string) ([]string, error)
 // getSliceSlice retrieves a slice of slice values from the specified XML-RPC method.
 func (c *Client) getSliceSlice(method string, args ...string) ([][]any, error) {
 	send := []interface{}{""}
-	send = append(send, args)
+	for _, a := range args {
+		send = append(send, a)
+	}
 
 	var v [][]any
 	err := c.xrc.Call(method, send, &v)


### PR DESCRIPTION
Fixes a bug in the slice handling that was introduced in v0.2.0

Updates github actions versions